### PR TITLE
Fix: 🐛 Update Broken Showcase Url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h3 align="center">Showcase 🎨</h3>
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/TylerAustInW/stylta-material-dark/refs/heads/Quickstart-MD/images/Showcase.png" alt="Stylta Material Dark Showcase">
+  <img src="https://raw.githubusercontent.com/TylerAustInW/stylta-material-dark/refs/heads/main/images/Showcase.png" alt="Stylta Material Dark Showcase">
 </div>
 
 <h3 align="center">


### PR DESCRIPTION
 includes a small change to the `README.md` file. The change updates the image source URL for the "Stylta Material Dark Showcase" 

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4): Updated the Showcase URL for the "Stylta Material Dark Showcase" 